### PR TITLE
fix the dang end of line issue

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "rules": {
         "no-anonymous-exports-page-templates": "warn",
         "limited-exports-page-templates": "warn",
-        "react/no-unescaped-entities": "warn"
+        "react/no-unescaped-entities": "warn",
+        "prettier/prettier": ["error", {"endOfLine": "auto"}, { "usePrettierrc": true }]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,8 +30,6 @@
         "react-hooks"
     ],
     "rules": {
-        "no-anonymous-exports-page-templates": "warn",
-        "limited-exports-page-templates": "warn",
         "react/no-unescaped-entities": "warn",
         "prettier/prettier": ["error", {"endOfLine": "auto"}, { "usePrettierrc": true }]
     }


### PR DESCRIPTION
 I BELIEVE THIS FIXES IT

Basically, even though there is prettier config file in the package, the linter wasn’t picking it up, so it was defaulting to the prettier recommended defaults which prefers `LF`. This change forces the linter to use any line endings (`auto`) and use the prettier config in the package.