### PR TITLE
#9 - Update mdx for grapple and climb large creatures

### DIFF
--- a/src/pages/conditions.tsx
+++ b/src/pages/conditions.tsx
@@ -178,7 +178,7 @@ const ConditionsPage = (): React.ReactElement => {
                 {links.map(link => (
                     <li key={link.url} className="listItemStyles">
                         <span>
-                            <h3>{link.text}</h3>
+                            <h3 id={link.text}>{link.text}</h3>
 
                             <ul>
                                 {link.description.map((item, index) => (

--- a/src/pages/grapple.mdx
+++ b/src/pages/grapple.mdx
@@ -1,0 +1,60 @@
+import '../styles/_defaults.scss'
+import '../styles/style.scss'
+
+<title>Grappling</title>
+
+# How to Grapple
+
+[Home](/)
+
+Ready to rassle?
+
+### In order to grapple you must:
+
+- Use the attack action to make a special melee attack (the grapple).
+    - If you have multiple attacks, this replaces one of them.
+- Be no more than one size smaller than your target.
+- Have at least one free hand.
+- Make a **Strength(Athletics)** check contested by the targets **Strength(Athletics)** or **Dexterity(Acrobatics)** check.
+
+If you succeed, the target is subject to the [Grappled](/conditions) condition. It is a free action to release the target.
+
+## Escaping a Grapple
+A grappled creature may use it's action to escape.
+
+Make a **Strength(Athletics)** or **Dexterity(Acrobatics)** check contested by your opponents **Strength(Athletics)** check.
+
+## Moving a Grappled Creature
+When you move, you can drag or carry a Grappled creature with you, but your speed is halved, unless the creature is two or more sizes smaller than you.
+
+## Shoving a Creature
+### In order to shove a creature, you must:
+
+- Use the Attack action to make a special melee attack (the shove). 
+    - If you have multiple attacks, this replaces one of them.
+- Be no more than one size smaller than your target.
+- Make a **Strength(Athletics)** check contested by the targets **Strength(Athletics)** or **Dexterity(Acrobatics)** check.
+
+If you succeed, you either knock the target [Prone](/conditions) or push it 5 feet away from you.
+
+>**_NOTE:_** You don't need a free hand to shove a target.
+
+## Climb onto a Bigger Creature
+To climb a creature bigger than you, you must:
+- Be at least two sizes smaller than your target.
+- Make a successful grapple check (**Strength(Athletics)** or **Dexterity(Acrobatics)** check contested by the targets **Dexterity(Acrobatics)**)
+
+**If successful:** The smaller creature:
+- Moves into the larger creatures space.
+- Moves with the target as long as the grapple is maintained.
+- Has advantage on attack rolls against the larger creature.
+- May move around the learger creatures space,treatign the space as difficult terrain.
+
+**Alternatively:** If the opponent is suitably large, it could be treated as difficult terrain for the purposed of jumping on it's back or clinging to a limb.
+
+#### What the larger grappled creature may do is up to GM discretion. For Example:
+
+**While Grappled, the larger creature may:**
+- Attack the smaller creature, perhaps depending on thier position.
+- Dislodge the smaller creature as an Action by making a **Strength(Athletics)** check contested by the smaller creatures  **Strength(Athletics)** or **Dexterity(Acrobatics)** check.
+

--- a/src/pages/grapple.mdx
+++ b/src/pages/grapple.mdx
@@ -17,7 +17,7 @@ Ready to rassle?
 - Have at least one free hand.
 - Make a **Strength(Athletics)** check contested by the targets **Strength(Athletics)** or **Dexterity(Acrobatics)** check.
 
-If you succeed, the target is subject to the [Grappled](/conditions) condition. It is a free action to release the target.
+If you succeed, the target is subject to the [Grappled](/conditions#Grappled) condition. It is a free action to release the target.
 
 ## Escaping a Grapple
 A grappled creature may use it's action to escape.
@@ -35,7 +35,7 @@ When you move, you can drag or carry a Grappled creature with you, but your spee
 - Be no more than one size smaller than your target.
 - Make a **Strength(Athletics)** check contested by the targets **Strength(Athletics)** or **Dexterity(Acrobatics)** check.
 
-If you succeed, you either knock the target [Prone](/conditions) or push it 5 feet away from you.
+If you succeed, you either knock the target [Prone](/conditions#Prone) or push it 5 feet away from you.
 
 >**_NOTE:_** You don't need a free hand to shove a target.
 

--- a/src/styles/_defaults.scss
+++ b/src/styles/_defaults.scss
@@ -36,8 +36,11 @@ button {
 
 ul,
 ol {
-  margin-bottom: 30px;
-  padding-left: 0;
+  list-style-position: inside;
+  list-style-type: default;
+  list-style: default;
+  margin-bottom: 10px;
+  padding-left: 5;
 }
 
 nav {
@@ -45,9 +48,11 @@ nav {
 }
 
 li {
+  list-style-position: inside;
+  list-style: disc;
   font-weight: 300px;
   font-size: 16px;
-  max-width: 560px;
+  max-width: 700px;
   margin-bottom: 10px;
 }
 

--- a/src/styles/_defaults.scss
+++ b/src/styles/_defaults.scss
@@ -36,10 +36,8 @@ button {
 
 ul,
 ol {
-  list-style-position: inside;
-  list-style-type: default;
-  list-style: default;
   margin-bottom: 10px;
+  padding-left: 0;
 }
 
 nav {
@@ -47,12 +45,11 @@ nav {
 }
 
 li {
-  list-style-position: inside;
-  list-style: disc;
   font-weight: 300px;
   font-size: 16px;
   max-width: 700px;
   margin-bottom: 10px;
+  margin-left: 2em;
 }
 
 a {

--- a/src/styles/_defaults.scss
+++ b/src/styles/_defaults.scss
@@ -40,7 +40,6 @@ ol {
   list-style-type: default;
   list-style: default;
   margin-bottom: 10px;
-  padding-left: 5;
 }
 
 nav {


### PR DESCRIPTION
This should close #9, close #18 

- Experimented with adding links to markdown
- Update styling to make bullets on ul/ol visible
- Will need to explore how styling works through gatsby markdown as markdown pages do not display like others generated by typescript
- Would love to add sizing charts to this page (or at least a link to sizing charts to address size comparisons for climbing larger creatures.