### PR TITLE
Trying out moving css to CSS modules over global css file

### DIFF
--- a/src/layout/page-layout.module.scss
+++ b/src/layout/page-layout.module.scss
@@ -1,0 +1,11 @@
+@import '../styles/variables';
+
+.content {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.pageStyles {
+  color: $primaryFontColor;
+  padding: 30px 0;
+}

--- a/src/layout/page-layout.tsx
+++ b/src/layout/page-layout.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 
 import { Outlet } from 'react-router-dom';
 
-type LayoutType = {
-    children: React.ReactElement[];
-};
+import styles from './page-layout.module.scss';
 
 export default function Layout(): React.ReactElement {
     return (
-        <div className="content">
-            <main className="page-styles">
+        <div className={styles.content}>
+            <main className={styles.pageStyles}>
                 <Outlet />
             </main>
         </div>

--- a/src/pages/epic-spells.tsx
+++ b/src/pages/epic-spells.tsx
@@ -1,9 +1,17 @@
 import { EpicLogo } from '../icons/epic';
 
+import styles from './epicSpells.module.scss';
+
 export const EpicSpells = () => {
     return (
-        <div>
-            <EpicLogo />
-        </div>
+        <>
+            <header className={styles.epicSpellHeader}>
+                <div className="spell">Your Spell</div>
+                <div className="logo">
+                    <EpicLogo />
+                </div>
+            </header>
+            <section>Create an epic spell.</section>
+        </>
     );
 };

--- a/src/pages/epicSpells.module.scss
+++ b/src/pages/epicSpells.module.scss
@@ -1,0 +1,4 @@
+.epicSpellHeader {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/styles/_defaults.scss
+++ b/src/styles/_defaults.scss
@@ -1,4 +1,5 @@
 @import './site-fonts';
+@import './variables';
 
 body {
   font-family: OpenSans, sans-serif;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,17 +1,11 @@
 @import './defaults';
-@import './variables';
 
 body {
   background-color: $backgroundColor;
 }
 
-.page-styles {
-  color: $primaryFontColor;
-  padding: 96px;
-}
-
 .reference-title {
-  color: '#663399';
+  color: #663399;
 }
 
 .codeStyles {


### PR DESCRIPTION
[Create React App comes with CSS Modules enabled](https://create-react-app.dev/docs/adding-a-css-modules-stylesheet/) and the global CSS file is getting cumbersome. In order to isolate our CSS (and force us to use components rather than global classes), I say we move all of our CSS from the global file and into CSS modules. 

This POC isn't perfect, but it's a start. Let me know what you think.